### PR TITLE
Enhance Ayon publisher node

### DIFF
--- a/client/ayon_comfyui/custom_nodes/ayon_publisher/PublishImage.py
+++ b/client/ayon_comfyui/custom_nodes/ayon_publisher/PublishImage.py
@@ -339,8 +339,7 @@ class PublishImage(AyonNode):
         except Exception as e:
             log.warning(f"Error initializing AYON data for input types: {e}")
 
-        # TODO: get variants and product types from project settings
-        variants = ["Main", "Other"]
+        # TODO: get product types from project settings
         product_types = ["render", "image"]
 
         return {
@@ -363,8 +362,8 @@ class PublishImage(AyonNode):
                     },
                 ),
                 "variant": (
-                    "COMBO",
-                    {"options": variants, "multi_select": False},
+                    "STRING",
+                    {"default": "Main"},
                 ),
                 "product_type": (
                     "COMBO",

--- a/client/ayon_comfyui/utils/ayon_publish.py
+++ b/client/ayon_comfyui/utils/ayon_publish.py
@@ -610,6 +610,12 @@ class AyonPublisher:
         except Exception:
             pass
 
+        prefix, _ = self._extract_frame_info(files[0])
+        print(f"@@prefix: {prefix}")
+        representation_name = prefix.rstrip(".") if prefix else os.path.splitext(
+            os.path.basename(files[0])
+        )[0]
+
         # Create a directory for the sequence
         sequence_publish_paths = []
         for file_path in files:
@@ -644,7 +650,7 @@ class AyonPublisher:
             representation_name=representation_name,
             files=sequence_publish_paths,
             is_sequence=True,
-            original_basename=os.path.splitext(os.path.basename(files[0]))[0],
+            original_basename=representation_name,
             tags=["review", "sequence"],
             template=template,
             resolution_width=res_w,


### PR DESCRIPTION
## Summary
- allow free text for variant on publisher node
- capture image resolution when publishing and store in version and representation attributes
- ensure representation names use file basenames and paths include them
- fetch newly created products if API only returns an ID

## Testing
- `python -m py_compile $(git ls-files '*.py')`