### PR TITLE
Improve publish metadata

### DIFF
--- a/client/ayon_comfyui/utils/ayon_publish.py
+++ b/client/ayon_comfyui/utils/ayon_publish.py
@@ -3,6 +3,8 @@ import json
 import shutil
 import re
 import uuid
+import hashlib
+from datetime import datetime
 from typing import Dict, Any, Optional, List, Tuple, Union
 
 from PIL import Image
@@ -68,6 +70,7 @@ class AyonPublisher:
             # Get folder
             folder = self._get_folder(project_name, folder_path)
             folder_id = folder["id"]
+            folder_type = folder.get("folderType") or folder.get("type")
 
             # Get or create product
             product = self._get_or_create_product(
@@ -77,6 +80,23 @@ class AyonPublisher:
 
             # Get next version
             next_version = self._get_next_version(project_name, product_id)
+
+            # Detect sequences in the files
+            sequences = self._detect_sequence(file_paths)
+
+            frame_start = frame_end = None
+            for seq_files in sequences.values():
+                _, start = self._extract_frame_info(seq_files[0])
+                _, end = self._extract_frame_info(seq_files[-1])
+                if start is not None:
+                    frame_start = start if frame_start is None else min(frame_start, start)
+                if end is not None:
+                    frame_end = end if frame_end is None else max(frame_end, end)
+
+            if frame_start is None:
+                frame_start = 1
+            if frame_end is None:
+                frame_end = frame_start
 
             # Determine resolution from the first file
             first_file = file_paths[0]
@@ -100,10 +120,9 @@ class AyonPublisher:
                 description,
                 res_width,
                 res_height,
+                frame_start,
+                frame_end,
             )
-
-            # Detect sequences in the files
-            sequences = self._detect_sequence(file_paths)
 
             # If representation_names not provided, derive from file extensions
             if not representation_names:
@@ -137,6 +156,7 @@ class AyonPublisher:
                         next_version,
                         template,
                         publish_root,
+                        folder_type,
                     )
                     representation_ids.append(result["representation_id"])
                     publish_paths.extend(result["publish_paths"])
@@ -154,6 +174,7 @@ class AyonPublisher:
                         next_version,
                         template,
                         publish_root,
+                        folder_type,
                     )
                     representation_ids.append(result["representation_id"])
                     publish_paths.append(result["publish_path"])
@@ -326,6 +347,9 @@ class AyonPublisher:
             description: Optional[str] = None,
             resolution_width: Optional[int] = None,
             resolution_height: Optional[int] = None,
+            frame_start: Optional[int] = None,
+            frame_end: Optional[int] = None,
+            fps: float = 25.0,
     ) -> str:
         """Create a new version."""
         author = (
@@ -340,9 +364,26 @@ class AyonPublisher:
             "product_id": product_id,
             "author": author,
             "status": "Pending review",
-            "attrib": {},
-            "data": {"comment": description or ""},
+            "step": 1,
+            "time": datetime.utcnow().strftime("%Y%m%dT%H%M%SZ"),
+            "attrib": {
+                "fps": fps,
+                "clipIn": 1,
+                "clipOut": 1,
+                "pixelAspect": 1.0,
+                "handleStart": 0,
+                "handleEnd": 0,
+            },
+            "data": {
+                "comment": description or "",
+                "colorspace": "scene_linear",
+            },
         }
+
+        if frame_start is not None:
+            version_data["attrib"]["frameStart"] = frame_start
+        if frame_end is not None:
+            version_data["attrib"]["frameEnd"] = frame_end
 
         if resolution_width is not None and resolution_height is not None:
             version_data["attrib"].update(
@@ -511,12 +552,26 @@ class AyonPublisher:
             self.logger.error(f"Failed to construct publish path: {str(e)}")
             raise
 
+    def _calculate_file_hash(self, file_path: str) -> str:
+        """Compute MD5 hash of a file."""
+        hash_md5 = hashlib.md5()
+        with open(file_path, "rb") as f:
+            for chunk in iter(lambda: f.read(8192), b""):
+                hash_md5.update(chunk)
+        return hash_md5.hexdigest()
+
     def _create_representation(
             self,
             project_name: str,
             version_id: str,
             representation_name: str,
             files: List[str],
+            folder_path: str,
+            product_name: str,
+            product_type: str,
+            version_number: int,
+            publish_root: Dict[str, Any],
+            folder_type: Optional[str] = None,
             is_sequence: bool = False,
             original_basename: Optional[str] = None,
             tags: List[str] = None,
@@ -530,11 +585,13 @@ class AyonPublisher:
 
         file_entries = []
         for file_path in files:
+            file_hash = self._calculate_file_hash(file_path)
             file_entries.append({
                 "id": uuid.uuid1().hex,
                 "name": os.path.basename(file_path),
                 "path": file_path,
                 "size": os.path.getsize(file_path),
+                "hash": file_hash,
             })
 
         rep_data = {
@@ -546,7 +603,16 @@ class AyonPublisher:
                 "colorspace": colorspace,
                 "originalBasename": original_basename or os.path.basename(files[0]),
                 "isSequence": is_sequence,
-                "context": self._get_context()
+                "context": self._get_context(
+                    project_name,
+                    folder_path,
+                    product_name,
+                    product_type,
+                    representation_name,
+                    version_number,
+                    publish_root,
+                    folder_type,
+                ),
             },
             "status": "Pending review",
             "attrib": {
@@ -568,8 +634,18 @@ class AyonPublisher:
 
         return representation_id
 
-    def _get_context(self) -> Dict[str, Any]:
-        """Build representation context from environment variables."""
+    def _get_context(
+            self,
+            project_name: str,
+            folder_path: str,
+            product_name: str,
+            product_type: str,
+            representation_name: str,
+            version_number: int,
+            publish_root: Dict[str, Any],
+            folder_type: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Build representation context from parameters and environment."""
         ayon_env = {k: v for k, v in os.environ.items() if k.startswith("AYON_")}
 
         user_name = (
@@ -578,18 +654,39 @@ class AyonPublisher:
             or os.getenv("USER")
         )
 
+        folder_parts = folder_path.strip("/").split("/") if folder_path else []
+        asset_name = folder_parts[-1] if folder_parts else ""
+        hierarchy = "/".join(folder_parts[:-1]) if len(folder_parts) > 1 else ""
+
         context = {
-            "project": {"name": ayon_env.get("AYON_PROJECT_NAME"), "code": "epi"},
-            "folder": {"path": ayon_env.get("AYON_FOLDER_PATH")},
-            "task": {"name": ayon_env.get("AYON_TASK_NAME")},
-            "user": {"name": user_name} if user_name else {},
+            "asset": asset_name,
+            "subset": product_name,
+            "family": product_type,
+            "hierarchy": hierarchy,
+            "project": {
+                "name": project_name,
+                "code": ayon_env.get("AYON_PROJECT_CODE", project_name[:3]),
+            },
+            "folder": {
+                "path": folder_path,
+                "name": asset_name,
+                "parents": folder_parts[:-1],
+                "type": folder_type,
+            },
+            "product": {"name": product_name, "type": product_type},
+            "representation": representation_name,
+            "task": {
+                "name": ayon_env.get("AYON_TASK_NAME"),
+                "type": os.getenv("AYON_TASK_TYPE"),
+                "short": os.getenv("AYON_TASK_SHORT"),
+            },
+            "user": user_name,
+            "username": user_name,
+            "version": version_number,
+            "root": {"publish": publish_root.get("windows")},
         }
 
-        cleaned = {
-            k: v
-            for k, v in context.items()
-            if v and all(vv is not None for vv in v.values())
-        }
+        cleaned = {k: v for k, v in context.items() if v not in (None, "", {})}
         return cleaned
 
     def _publish_sequence(
@@ -604,7 +701,8 @@ class AyonPublisher:
             version_id: str,
             version_number: int,
             template: Dict[str, Any],
-            publish_root: Dict[str, Any]
+            publish_root: Dict[str, Any],
+            folder_type: Optional[str] = None
     ) -> Dict[str, Any]:
         """Publish a sequence of files."""
         # Get frame numbers for sequence
@@ -656,6 +754,12 @@ class AyonPublisher:
             version_id=version_id,
             representation_name=representation_name,
             files=sequence_publish_paths,
+            folder_path=folder_path,
+            product_name=product_name,
+            product_type=product_type,
+            version_number=version_number,
+            publish_root=publish_root,
+            folder_type=folder_type,
             is_sequence=True,
             original_basename=representation_name,
             tags=["review", "sequence"],
@@ -688,7 +792,8 @@ class AyonPublisher:
             version_id: str,
             version_number: int,
             template: Dict[str, Any],
-            publish_root: Dict[str, Any]
+            publish_root: Dict[str, Any],
+            folder_type: Optional[str] = None
     ) -> Dict[str, Any]:
         """Publish a single file."""
         res_w = res_h = None
@@ -723,6 +828,12 @@ class AyonPublisher:
             version_id=version_id,
             representation_name=representation_name,
             files=[publish_path],
+            folder_path=folder_path,
+            product_name=product_name,
+            product_type=product_type,
+            version_number=version_number,
+            publish_root=publish_root,
+            folder_type=folder_type,
             is_sequence=False,
             template=template,
             original_basename=os.path.splitext(os.path.basename(file_path))[0],


### PR DESCRIPTION
## Summary
- add file hashing and richer context info for representations
- capture folder type and task details when building context
- provide folder type in publish calls

## Testing
- `python -m py_compile $(git ls-files '*.py')`