### PR TITLE
Fix task name handling in ayon_publish

### DIFF
--- a/client/ayon_comfyui/utils/ayon_publish.py
+++ b/client/ayon_comfyui/utils/ayon_publish.py
@@ -66,6 +66,7 @@ class AyonPublisher:
             folder_path: AYON folder path
             product_name: Name of the product to create or use
             product_type: Type of product (default: "image")
+            task_name: Name of the task for context information
             representation_names: List of representation names (derived from file extensions if None)
             description: Optional description for the version
 
@@ -192,6 +193,7 @@ class AyonPublisher:
                         folder_type,
                         product_name,
                         product_type,
+                        task_name,
                         files[0],
                         representation_name,
                         file_ext,
@@ -492,7 +494,10 @@ class AyonPublisher:
             output: str = "",
             task_name: str = "",
     ) -> str:
-        """Construct publish path using anatomy templates, handling empty optional fields."""
+        """Construct publish path using anatomy templates.
+
+        The ``task_name`` parameter is injected into template data.
+        """
         self.logger.info("[PATH] Constructing publish path")
         try:
             self.logger.debug(f"[PATH] Using template: {template}")
@@ -594,6 +599,7 @@ class AyonPublisher:
             version_number: int,
             publish_root: Dict[str, Any],
             root_paths: Dict[str, Any],
+            task_name: str = "",
             is_sequence: bool = False,
             original_basename: Optional[str] = None,
             tags: List[str] = None,
@@ -602,7 +608,10 @@ class AyonPublisher:
             resolution_width: Optional[int] = None,
             resolution_height: Optional[int] = None,
     ) -> str:
-        """Create a representation with the given files."""
+        """Create a representation with the given files.
+
+        Args include ``task_name`` to set context information.
+        """
         self.logger.info(f"[REPRESENTATION] Creating representation '{representation_name}'")
 
         file_entries = []
@@ -633,6 +642,7 @@ class AyonPublisher:
                     representation_name,
                     version_number,
                     root_paths,
+                    task_name,
                 ),
             },
             "status": "Pending review",
@@ -665,8 +675,12 @@ class AyonPublisher:
             representation_name: str,
             version_number: int,
             root_paths: Dict[str, Any],
+            task_name: str = "",
     ) -> Dict[str, Any]:
-        """Build representation context from parameters and environment."""
+        """Build representation context from parameters and environment.
+
+        The ``task_name`` argument overrides ``AYON_TASK_NAME`` if provided.
+        """
         ayon_env = {k: v for k, v in os.environ.items() if k.startswith("AYON_")}
 
         user_name = (
@@ -700,7 +714,7 @@ class AyonPublisher:
             "product": {"name": product_name, "type": product_type},
             "representation": representation_name,
             "task": {
-                "name": ayon_env.get("AYON_TASK_NAME"),
+                "name": task_name or ayon_env.get("AYON_TASK_NAME"),
                 "type": ayon_env.get("AYON_TASK_TYPE"),
                 "short": ayon_env.get("AYON_TASK_SHORT"),
             },
@@ -788,6 +802,7 @@ class AyonPublisher:
             version_number=version_number,
             publish_root=publish_root,
             root_paths=root_paths,
+            task_name=task_name,
             is_sequence=True,
             original_basename=representation_name,
             tags=["review", "sequence"],
@@ -815,6 +830,7 @@ class AyonPublisher:
             folder_type: Optional[str],
             product_name: str,
             product_type: str,
+            task_name: str,
             file_path: str,
             representation_name: str,
             file_ext: str,
@@ -824,7 +840,7 @@ class AyonPublisher:
             publish_root: Dict[str, Any],
             root_paths: Dict[str, Any]
     ) -> Dict[str, Any]:
-        """Publish a single file."""
+        """Publish a single file with optional ``task_name`` for context."""
         res_w = res_h = None
         try:
             with Image.open(file_path) as img:
@@ -833,13 +849,14 @@ class AyonPublisher:
             pass
 
         # Construct publish path
-        publish_path = self._construct_publish_path(
-            file_path=file_path,
-            project_name=project_name,
-            folder_path=folder_path,
-            product_name=product_name,
-            product_type=product_type,
-            representation_name=representation_name,
+            publish_path = self._construct_publish_path(
+                file_path=file_path,
+                project_name=project_name,
+                folder_path=folder_path,
+                task_name=task_name,
+                product_name=product_name,
+                product_type=product_type,
+                representation_name=representation_name,
             version=version_number,
             template=template,
             publish_root=publish_root,
@@ -864,6 +881,7 @@ class AyonPublisher:
             version_number=version_number,
             publish_root=publish_root,
             root_paths=root_paths,
+            task_name=task_name,
             is_sequence=False,
             template=template,
             original_basename=os.path.splitext(os.path.basename(file_path))[0],


### PR DESCRIPTION
## Summary
- propagate `task_name` argument through the publishing helpers
- include `task_name` in context building and path templates
- document task name usage in docstrings

## Testing
- `python -m py_compile client/ayon_comfyui/utils/ayon_publish.py`
- `find client -name '*.py' | xargs python -m py_compile`